### PR TITLE
minor fixes for python3 and pyflakes

### DIFF
--- a/dirichlet_conrey.pyx
+++ b/dirichlet_conrey.pyx
@@ -42,6 +42,7 @@ from sage.all import factor,        \
                      imag
 
 from sage.modular.dirichlet import DirichletCharacter
+from sage.structure.richcmp import richcmp
 
 import cmath
 
@@ -746,7 +747,7 @@ cdef class DirichletCharacter_conrey:
     def __call__(self, long m):
         return self.value(m)
 
-    def __cmp__(self, DirichletCharacter_conrey other):
+    def _richcmp_(self, DirichletCharacter_conrey other, op):
         r"""
         Compare self to other. Return equality if and only if the moduli and
         the character number are the same. When different, characters are first
@@ -770,9 +771,9 @@ cdef class DirichletCharacter_conrey:
             True
         """
         if(self._parent.q != other._parent.q):
-            return cmp(self._parent.q, other._parent.q)
+            return richcmp(self._parent.q, other._parent.q)
         else:
-            return cmp(self._n, other._n)
+            return richcmp(self._n, other._n)
 
     def conductor(self):
         r"""

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@
 # and the cython documentation
 
 # Build using 'python setup.py'
-import distutils.sysconfig, os, sys
+import os, sys
 #from distutils.core import setup, Extension
 from setuptools import setup, Extension
 from Cython.Distutils import build_ext
 
 if not os.environ.has_key('SAGE_ROOT'):
-    print "    ERROR: The environment variable SAGE_ROOT must be defined."
+    print("    ERROR: The environment variable SAGE_ROOT must be defined.")
     sys.exit(1)
 else:
     SAGE_ROOT  = os.environ['SAGE_ROOT']

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import os, sys
 from setuptools import setup, Extension
 from Cython.Distutils import build_ext
 
-if not os.environ.has_key('SAGE_ROOT'):
+if not 'SAGE_ROOT' in os.environ:
     print("    ERROR: The environment variable SAGE_ROOT must be defined.")
     sys.exit(1)
 else:
@@ -24,7 +24,7 @@ ext_modules = [Extension('dirichlet_conrey', sources=['dirichlet_conrey.pyx', ],
                      include_dirs=[SAGE_SRC + '/sage/ext'],
                      extra_compile_args = extra_compile_args,
                      extra_link_args = extra_link_args)]
-                     
+
 
 include_dirs = [SAGE_LOCAL + "/include/csage/",
                 SAGE_LOCAL + "/include/",
@@ -44,4 +44,4 @@ setup(name='DirichletConrey',
       include_dirs = include_dirs,
       cmdclass = {'build_ext' : build_ext})
 
-    
+

--- a/test_conrey.py
+++ b/test_conrey.py
@@ -1,5 +1,5 @@
-from sage.all import *
-from dirichlet_conrey import *
+from sage.all import xrange, randint, Mod, prod, gcd
+from dirichlet_conrey import DirichletGroup_conrey
 
 def test_conrey(nranges=[(20,100),(200,1000),(500,500000)]):
   for n,r in nranges:
@@ -13,7 +13,7 @@ def test_conrey(nranges=[(20,100),(200,1000),(500,500000)]):
               assert  q <= 2 or G.zeta_order() == inv[0]
               assert  cinv == inv
           except:
-              print 'group error'
+              print( 'group error')
               return q, inv, G
           if q > 2:
               m = 0
@@ -27,16 +27,16 @@ def test_conrey(nranges=[(20,100),(200,1000),(500,500000)]):
                       try:
                           assert chi.logvalue(n) == -1
                       except:
-                          print 'non unit value error'
+                          print( 'non unit value error')
                           return chi, n, r
                   elif q < 10^6:
                       try:
                           ref = chi.sage_character()(n).n().real()
-                          new = N(chi(n).real)
+                          new = (chi(n).real).n()
                           assert abs(ref - new) < 1e-5
                       except:
-                          print 'unit value error'
+                          print( 'unit value error')
                           return chi, n
               except:
-                  print 'char error'
+                  print( 'char error')
                   return chi, n, r

--- a/test_conrey.py
+++ b/test_conrey.py
@@ -1,10 +1,12 @@
-from sage.all import xrange, randint, Mod, prod, gcd
+from sage.all import randint, Mod, prod, gcd, N
+import pyximport; pyximport.install()
 from dirichlet_conrey import DirichletGroup_conrey
 
 def test_conrey(nranges=[(20,100),(200,1000),(500,500000)]):
   for n,r in nranges:
-      for i in xrange(n):
+      for i in range(n):
           q = randint(1,r)
+          print("n, r, i, q = {}, {}, {}, {}".format(n,r,i,q))
           G = DirichletGroup_conrey(q)
           inv = G.invariants()
           cinv = tuple([ Mod(g,q).multiplicative_order() for g in G.gens() ])
@@ -32,7 +34,7 @@ def test_conrey(nranges=[(20,100),(200,1000),(500,500000)]):
                   elif q < 10^6:
                       try:
                           ref = chi.sage_character()(n).n().real()
-                          new = (chi(n).real).n()
+                          new = N(chi(n).real)
                           assert abs(ref - new) < 1e-5
                       except:
                           print( 'unit value error')


### PR DESCRIPTION
After building Sage with python3 (as is now recommended for developers to avoid regressions) I had some errors installing this package because of print statements of the form print "something" instead of print("something").  These were only in the test file.  I fixed those and while I was at it I changed the import statements to keep pyflakes (actually pyflakes3) happy.

Please check line 35 of the test file where I changed N() to .n() (as N is undefined after the import changes) and am not sure if that is what is intended.