### PR TITLE
Use full notation in richcmp

### DIFF
--- a/dirichlet_conrey.pyx
+++ b/dirichlet_conrey.pyx
@@ -747,7 +747,7 @@ cdef class DirichletCharacter_conrey:
     def __call__(self, long m):
         return self.value(m)
 
-    def _richcmp_(self, DirichletCharacter_conrey other, op):
+    def __richcmp__(self, DirichletCharacter_conrey other, op):
         r"""
         Compare self to other. Return equality if and only if the moduli and
         the character number are the same. When different, characters are first
@@ -771,9 +771,9 @@ cdef class DirichletCharacter_conrey:
             True
         """
         if(self._parent.q != other._parent.q):
-            return richcmp(self._parent.q, other._parent.q)
+            return richcmp(self._parent.q, other._parent.q, op)
         else:
-            return richcmp(self._n, other._n)
+            return richcmp(self._n, other._n, op)
 
     def conductor(self):
         r"""


### PR DESCRIPTION
This is a small update on top of John Cremona's recent update to python3-compatible code. I hadn't noticed before, but richcmp expects to receive the op as a third argument.

This affected test branches of the LMFDB, which prompted me to notice.