### PR TITLE
true division

### DIFF
--- a/dirichlet_conrey.pyx
+++ b/dirichlet_conrey.pyx
@@ -1462,9 +1462,9 @@ cdef class DirichletCharacter_conrey:
             f = 0
             m = alpha
             while m % 2 == 0:
-                m /= 2
+                m //= 2
                 f += 1
-            conductor = q_even / 2**f
+            conductor = q_even // 2**f
             index = power_mod(5, m, conductor)
             if epsilon == -1:
                 index = conductor - index


### PR DESCRIPTION
This corrects the following bug in #10.

The source was a division in conductor casting something to a float.